### PR TITLE
Pass debug details to onChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ function evolve (get, set, action) {
   }
 }
 
-function render (atom) {
-  console.log('new state', atom.get())
+function render (atom, details) {
+  console.log('change', {
+    id: details.id,
+    action: details.action,
+    state: atom.get()
+  })
 }
 
 atom.split({ count: 5 })
@@ -101,7 +105,9 @@ Create an atom.
   * `get()` - get current state
   * `set(update)` - extend the state with this new value
   * `action` - an object of shape `{ type, payload }`
-* `render(atom)` - a function called on each state change
+* `render(atom, details)` - a function called on each state change
+  * `atom` - atom itself
+  * `details` - an object of shape { id, action }, purely for debugging
 
 A note on `set` - when calling set in `evolve`, it extends the state using Object.assign. But if you'd like to mutate the object simply pass the same state object to `set` and it will record that as the new state.
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,19 @@
 /**
  * Minimal state management.
  *
- * const evolve = (get, set, action) => set({ counter: get().counter + 1 })
- * const atom = createAtom({ counter: 1 }, evolve, render)
+ * const evolve = (get, set, action) => set({ count: get().count + 1 })
+ * const render = (atom, details) => console.log(details, atom.get())
+ * const atom = createAtom({ count: 1 }, evolve, render)
  *
- * atom.get() // { counter: 1 }
+ * atom.get() // { count: 1 }
  * atom.split('increment') // pass action
  * atom.split('increment', { by: 2 }) // pass action with payload
- * atom.split({ counter: 0 }) // set new state value directly, extends
- *
+ * atom.split({ count: 0 }) // set new state value directly, extends
  */
-module.exports = function createAtom (initialState, evolve, render) {
+module.exports = function createAtom (initialState, evolve, render, merge) {
+  var actionCount = 0
   var state = initialState || {}
+  merge = merge || Object.assign
   var atom = { get: get, split: split }
   return atom
 
@@ -19,20 +21,25 @@ module.exports = function createAtom (initialState, evolve, render) {
     return state
   }
 
-  function set (nextState) {
-    state === nextState
-      ? state = nextState
-      : state = Object.assign({}, state, nextState)
-    render && render(atom)
-    return state
+  function createSet (id, action) {
+    return function set (nextState) {
+      state === nextState
+        ? state = nextState
+        : state = merge({}, state, nextState)
+      render && render(atom, { id: id, action: action })
+      return state
+    }
   }
 
   function split (type, payload) {
-    if (typeof type === 'string') {
-      var action = { type: type, payload: payload }
-      evolve(get, set, action)
-    } else {
-      set(type)
+    if (typeof type !== 'string') {
+      payload = type
+      type = null
     }
+    var action = { type: type, payload: payload }
+    var set = createSet(++actionCount, action)
+    action.type
+      ? evolve(get, set, action)
+      : set(action.payload)
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@
  * atom.split('increment', { by: 2 }) // pass action with payload
  * atom.split({ count: 0 }) // set new state value directly, extends
  */
-module.exports = function createAtom (initialState, evolve, render, merge) {
+module.exports = function createAtom (initialState, evolve, render, extend) {
   var actionCount = 0
   var state = initialState || {}
-  merge = merge || Object.assign
+  extend = extend || Object.assign
   var atom = { get: get, split: split }
   return atom
 
@@ -25,7 +25,7 @@ module.exports = function createAtom (initialState, evolve, render, merge) {
     return function set (nextState) {
       state === nextState
         ? state = nextState
-        : state = merge({}, state, nextState)
+        : state = extend({}, state, nextState)
       render && render(atom, { id: id, action: action })
       return state
     }


### PR DESCRIPTION
On change now gets passed the action that caused this change. Can be useful to trace each `set` of async actions.

Feature creep?

The reason I started thinking about this is to try and understand what the differences between tiny-atom and redux are. I think, the tradeoff is that atom is sort of much more straightforward to use, as we've seen in our app. But in redux, you get a bit more debuggability and testability (?). In particular, when an async action creator dispatches a new action such as 'RECEIVE_BLA', you can see what payload was received. Is that important? Is it important to be able to dispatch actions from the reducer? I don't know, we'll see. Let's keep tiny-atom simple and see where it gets us! :)

So yeah, having said that, not sure this is a feature creep or a useful debug hook.. I did compromise code readability and performance slightly.