### PR TITLE
Change evolve signature to (get, split, action) - more power!

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,45 +1,50 @@
 /**
  * Minimal state management.
  *
- * const evolve = (get, set, action) => set({ count: get().count + 1 })
+ * const evolve = (get, split, action) => split({ count: get().count + 1 })
  * const render = (atom, details) => console.log(details, atom.get())
  * const atom = createAtom({ count: 1 }, evolve, render)
  *
  * atom.get() // { count: 1 }
- * atom.split('increment') // pass action
- * atom.split('increment', { by: 2 }) // pass action with payload
- * atom.split({ count: 0 }) // set new state value directly, extends
+ * atom.split('increment') // action
+ * atom.split('increment', { by: 2 }) // action with payload
+ * atom.split({ count: 0 }) // update state directly
  */
 module.exports = function createAtom (initialState, evolve, render, extend) {
-  var actionCount = 0
+  var actionSeq = 0
   var state = initialState || {}
   extend = extend || Object.assign
-  var atom = { get: get, split: split }
+  var atom = { get: get, split: createSplit() }
   return atom
 
   function get () {
     return state
   }
 
-  function createSet (id, action) {
-    return function set (nextState) {
-      state === nextState
-        ? state = nextState
-        : state = extend({}, state, nextState)
-      render && render(atom, { id: id, action: action })
-      return state
-    }
+  function set (nextState, action, seq) {
+    var prevState = state
+    state === nextState
+      ? state = nextState
+      : state = extend({}, state, nextState)
+    render && render(atom, {
+      seq: seq,
+      action: action || { payload: nextState },
+      update: nextState,
+      prev: prevState
+    })
+    return state
   }
 
-  function split (type, payload) {
-    if (typeof type !== 'string') {
-      payload = type
-      type = null
+  function createSplit (sourceAction, seq) {
+    return function split (type, payload) {
+      if (typeof type !== 'string') {
+        if (!sourceAction) actionSeq++
+        return set(type, sourceAction, seq || actionSeq)
+      } else {
+        actionSeq++
+        var action = { type: type, payload: payload }
+        evolve(get, createSplit(action, actionSeq), action)
+      }
     }
-    var action = { type: type, payload: payload }
-    var set = createSet(++actionCount, action)
-    action.type
-      ? evolve(get, set, action)
-      : set(action.payload)
   }
 }


### PR DESCRIPTION
Backwards compatible! (Except for the changes object).

I think this could be a better way to go about it. Basically, it's the same tiny-atom we know and love, but you can also split actions.

Debugging is neater now too with change providing `{ seq, action, update, prev }`.