### PR TITLE
Add atom.observe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+* Add `const dispose = atom.observe(atom => {})` - useful when passing atom around. Allows for separation of concerns where a self contained module can depend on atom changes as well as update atom.
+* **BREAKING** A real edge case, but `render` can't be passed as null anymore in combination with `options`. Instead of `createAtom(initialState, evolve, null, options)` do `createAtom(initialState, evolve, options)`
+
 ## 0.5.1
 
 * Updated docs and README

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Create an atom.
   * `action` - an object of shape `{ type, payload }`
 * `render(atom)` - called on each state update
 
+All parameters are optional, but typically you'll want to use at least initialState and evolve.
+
 Available options:
 
 * `options.debug(info)` - called on each `action` and `update` with info object of shape `{ type, atom, action, sourceActions, prevState }`
@@ -100,3 +102,7 @@ Can be used in 2 ways:
 
 * `atom.split(type, payload)` - send an action to `evolve`.
 * `atom.split(update)` - update the state with the `update` object, doesn't go via `evolve`.
+
+### `atom.observe`
+
+Register a callback for when atom changes. This can be used in addition or instead of the `render` callback. Returns the dispose function.

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -18,6 +18,8 @@ Available options:
 * `options.debug(info)` - called on each `action` and `update` with info object of shape `{ type, atom, action, sourceActions, prevState }`
 * `options.merge(state, update)` - called each time `split(update)` is called. Default implementation is `(state, update) => Object.assign({}, state, update)`. You can use this hook to use a different data structure for your state, such as Immutable. Or you could use it to extend the state instead of cloning with `Object.assign(state, update)` if that makes performance or architectural difference.
 
+All parameters are optional, but typically you'll want to use at least initialState and evolve.
+
 ### `atom.get`
 
 Get current state.
@@ -28,3 +30,7 @@ Can be used in 2 ways:
 
 * `atom.split(type, payload)` - send an action to `evolve`.
 * `atom.split(update)` - update the state with the `update` object, doesn't go via `evolve`.
+
+### `atom.observe`
+
+Register a callback for when atom changes. This can be used in addition or instead of the `render` callback. Returns the dispose function.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal, yet awesome, state management.",
   "main": "index.js",
   "scripts": {
+    "coverage": "nyc --reporter html mocha",
     "test": "standard && standard5 && nyc mocha"
   },
   "contributors": [

--- a/react.js
+++ b/react.js
@@ -1,11 +1,8 @@
 var React = require('react')
 var Component = React.Component
 
-function propsValidation (props, propName, componentName) {
-  if (typeof props === 'object') {
-    return null
-  }
-  return new Error('Invalid prop ' + propName + ' supplied to componentName')
+function Any () {
+  return null
 }
 
 function ProvideAtom () { Component.apply(this, arguments) }
@@ -13,9 +10,7 @@ function ProvideAtom () { Component.apply(this, arguments) }
 ProvideAtom.__proto__ = Component
 ProvideAtom.prototype = Object.create(Component.prototype)
 ProvideAtom.prototype.constructor = ProvideAtom
-ProvideAtom.childContextTypes = {
-  atom: propsValidation
-}
+ProvideAtom.childContextTypes = { atom: Any }
 ProvideAtom.prototype.getChildContext = function getChildContext () {
   return { atom: this.props.atom }
 }
@@ -31,9 +26,7 @@ function ConnectAtom (props, context) {
   return render(data)
 }
 
-ConnectAtom.contextTypes = {
-  atom: propsValidation
-}
+ConnectAtom.contextTypes = { atom: Any }
 
 module.exports.ProvideAtom = ProvideAtom
 module.exports.ConnectAtom = ConnectAtom


### PR DESCRIPTION
Mixed feelings on this one. It seemed like a good idea when I started. It can be really useful to be able to observe atom in different areas of the app. For example, it came up in `play` app, where I had independent behaviours like

```js
boom(atom) // fireworks
flash(atom) // error messages
orientation(atom) // tracking device orientation
```

But `boom` needed to also know when atom updated, to react to it and display the fireworks. So I couldn't just add it like flash and orientation. I had to move it to `render` function. Which seemed like, meh, that's not self contained.

Having said, mixed feelings, because maybe a better thing in that case would have been to render fireworks in the App component anyway and then I kinda wouldn't have had this problem tbh. So like, not a real use case.

Also, this messes up the "one way to do things" vibe. E.g. now you can use `render` or `observe` :( I'm considering removing render in favor of observe. But then you lose a tiny bit of that one liner simplicity.. So yeah, as I said, mixed feelings.

For example, if `atom.observe()` existed, you can make the `ProvideAtom` more easy to use where one doesn't need the extra render function wrapper. We could also provide the debouncing logic, since that's the best practise anyway. But without observe, it's not possibly to implement such feature easily. Which just shows that `observe` is really more powerful than render callback.

```js
const atom = createAtom({ count: 1 }, evolve)
atom.observe(render)
```

2 lines now... :)

It's `observe` and not `subscribe` since that's still accurate, and fits well with the theme of `atom` and `split`.

So all in all, the options are:

1. Don't add `observe`
2. Add `observe` in addition to `render`
3. Replace `render` with `observe` (and make ProvideAtom observe+debounce+rerender)
4. Just use redux :-"
