### PR TITLE
Pass props to map function

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -15,8 +15,9 @@ class ProvideAtom extends React.Component {
 
 ProvideAtom.childContextTypes = { atom: Any }
 
-function ConnectAtom ({ map, render, children }, { atom }) {
-  render = render || children
+function ConnectAtom (props, { atom }) {
+  const { map } = props
+  const render = props.render || props.children
   const data = map ? map(atom.get(), atom.split) : { state: atom.get(), split: atom.split }
   return render(data)
 }


### PR DESCRIPTION
This should've always been there so it is passed to the `map` fn. Gonna release this as 1.2.6