### PR TITLE
Add debug mode that logs why components rerender to help optimise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 The version 2.0.0 wasn't ready for prime time and should have been released under both beta channel and beta name. We're doing this with 3.0.0 instead.
 
-Summary of changes
+Summary of changes:
 
+* Version 3.0.0 brings back `<Provider />`, because it's a great way of wiring up the application lazily at runtime instead of at module export time.
 * New logger, both `tiny-atom/log` and `tiny-atom/devtools` are now factory functions that need to be called to create the actual log function. This is so they could take options, e.g. `log({ diff: false })`. The new logger outputs simpler looking output, prints the diff of all the state changes and uses emojis 🙌!
-* Version 3.0.0 brings back `<Provider />`, because it's a great way of wiring up the application at runtime. This makes it easier to construct the atom lazily and inject it into the render tree via Provider at runtime.
+* New debug mode for preact/react `<Consumer />` and `connect()` that logs details on why connected components rerender. This should help greatly with optimising the application to avoid needless rerenders. Turn on by setting `debug` prop on the `Provider` or `Consumer`, e.g. `<Provider debug />`.
 * Nicer, more realistic examples!
 
 ## 2.0.0

--- a/examples/preact-example/App.js
+++ b/examples/preact-example/App.js
@@ -15,7 +15,7 @@ const actions = [
   'addItem'
 ]
 
-module.exports = () => (
+const App = () => (
   <Consumer map={map} actions={actions}>
     {({ todo, hint, updateItem, completeItem, addItem }) => (
       <div className='App'>
@@ -49,6 +49,8 @@ module.exports = () => (
     )}
   </Consumer>
 )
+
+module.exports = App
 
 function onSubmit (addItem, $input) {
   return function (e) {

--- a/examples/preact-example/actions.js
+++ b/examples/preact-example/actions.js
@@ -38,12 +38,12 @@ module.exports.actions = {
     set({ todo: { input } })
   },
 
-  showHint: ({ set }) => {
-    set({ hint: { show: true } })
+  showHint: ({ get, set }) => {
+    if (!get().hint.show) set({ hint: { show: true } })
   },
 
-  hideHint: ({ set }) => {
-    set({ hint: { show: false } })
+  hideHint: ({ get, set }) => {
+    if (get().hint.show) set({ hint: { show: false } })
   },
 
   trackEvent: ({ get, set }, event) => {

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,55 @@
+const c = console
+const tryCatch = (fn, elseFn) => { try { fn() } catch (e) { elseFn() } }
+const log = (...args) => c.log(...args)
+const groupStart = (...args) => tryCatch(() => c.groupCollapsed(...args), () => c.log(...args))
+const groupEnd = () => tryCatch(() => c.groupEnd(), () => {})
+const warn = (...args) => tryCatch(() => c.warn(...args), () => {})
+
+const dictionary = {
+  E: { color: '#2196F3', text: 'CHANGED:' },
+  S: { color: '#F44336', text: 'CHANGED:' },
+  N: { color: '#4CAF50', text: 'ADDED:' }
+}
+
+function style (kind) {
+  return `color: ${dictionary[kind].color}; font-weight: bold;`
+}
+
+function stringify (v) {
+  return typeof v === 'function' ? v.toString() : JSON.stringify(v)
+}
+
+function printDiff (prev, next) {
+  for (let i in prev) {
+    if (prev[i] !== next[i]) {
+      const same = stringify(prev[i]) === stringify(next[i])
+      const kind = same ? 'S' : 'E'
+      groupStart(`%c   ${dictionary[kind].text}`, style(kind), i, same ? '- values look the same!' : '')
+      log('prev', prev[i])
+      log('next', next[i])
+      groupEnd()
+    }
+  }
+  for (let i in next) {
+    if (!(i in prev)) {
+      const kind = 'N'
+      groupStart(`%c   ${dictionary[kind].text}`, style(kind), i)
+      log('next', next[i])
+      groupEnd()
+    }
+  }
+  return false
+}
+
+// This is to uglify out this entire module in production
+if (process.env.NODE_ENV !== 'production') {
+  module.exports.children = function (component, prevChildren, nextChildren) {
+    warn(component, 'will rerender – children changed')
+    console.log(`%c   ${dictionary['E'].text}`, style('E'), prevChildren, '→', nextChildren)
+  }
+
+  module.exports.props = function (component, prevProps, nextProps) {
+    warn(component, 'will rerender – props changed')
+    printDiff(prevProps, nextProps)
+  }
+}


### PR DESCRIPTION
Setting `<Provider debug />` or `<Consumer debug />` or `connect(map, actions, { debug: true })` turns on logging about why components rerender and attempts to identify which prop changes are avoidable, i.e. the content is the same but reference changed.

<img width="815" alt="image" src="https://user-images.githubusercontent.com/324440/43552021-f8623474-95e0-11e8-9138-b554f87aaadd.png">
